### PR TITLE
REST API - NodeJS/Express

### DIFF
--- a/rest_api.js
+++ b/rest_api.js
@@ -2,14 +2,18 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const app = express();
 
+//List of counters in a map/dictionary format
 let counters = new Map();
+
+// convert map to object to send as a response body
 function map_to_object(map) {
-  const out = Object.create(null)
+  const out = Object.create(null);
   map.forEach((value, key) => {
-      out[key] = value
+      out[key] = value;
   })
-  return out
+  return out;
 }
+
 app.use(bodyParser.json());
 
 app.get('/counters/',(req,res)=>{
@@ -42,6 +46,15 @@ app.delete('/counters/:counter',(req, res)=>{
   counters.set(counter_name,  counters.get(counter_name)-1);
   if (counters.get(counter_name) <= 0) counters.delete(counter_name);
   res.send(map_to_object(counters));
+});
+
+app.get('/counters/:counter',(req,res)=>{
+  let counter_name = req.params.counter;
+  if (! counters.has(counter_name)) {
+    res.status(404).send();
+    return;
+  }
+  res.send(counters.get(counter_name).toString());
 });
 
 app.listen('3000');

--- a/rest_api.js
+++ b/rest_api.js
@@ -3,7 +3,6 @@ const bodyParser = require('body-parser');
 const app = express();
 
 let counters = new Map();
-
 function map_to_object(map) {
   const out = Object.create(null)
   map.forEach((value, key) => {
@@ -31,6 +30,17 @@ app.put('/counters/:counter',(req, res)=>{
     return;
   }
   counters.set(counter_name,  counters.get(counter_name)+1);
+  res.send(map_to_object(counters));
+});
+
+app.delete('/counters/:counter',(req, res)=>{
+  let counter_name = req.params.counter;
+  if (! counters.has(counter_name)) {
+    res.status(404).send();
+    return;
+  }
+  counters.set(counter_name,  counters.get(counter_name)-1);
+  if (counters.get(counter_name) <= 0) counters.delete(counter_name);
   res.send(map_to_object(counters));
 });
 

--- a/rest_api.js
+++ b/rest_api.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const app = express();
+
+let counters = new Map();
+app.get('/counters/',(req,res)=>{
+  res.send(counters);
+});
+
+app.listen('3000');

--- a/rest_api.js
+++ b/rest_api.js
@@ -3,17 +3,35 @@ const bodyParser = require('body-parser');
 const app = express();
 
 let counters = new Map();
+
+function map_to_object(map) {
+  const out = Object.create(null)
+  map.forEach((value, key) => {
+      out[key] = value
+  })
+  return out
+}
 app.use(bodyParser.json());
 
 app.get('/counters/',(req,res)=>{
-  res.send(counters);
+  res.send(map_to_object(counters));
 });
 
 app.post('/counters',(req,res)=>{
   for (const [key, value] of Object.entries(req.body)) {
-    counters[key] = value;
+    counters.set(key, value);
   }
-  res.send(counters);
+  res.send(map_to_object(counters));
+});
+
+app.put('/counters/:counter',(req, res)=>{
+  let counter_name = req.params.counter;
+  if (! counters.has(counter_name)) {
+    res.status(404).send();
+    return;
+  }
+  counters.set(counter_name,  counters.get(counter_name)+1);
+  res.send(map_to_object(counters));
 });
 
 app.listen('3000');

--- a/rest_api.js
+++ b/rest_api.js
@@ -1,8 +1,18 @@
 const express = require('express');
+const bodyParser = require('body-parser');
 const app = express();
 
 let counters = new Map();
+app.use(bodyParser.json());
+
 app.get('/counters/',(req,res)=>{
+  res.send(counters);
+});
+
+app.post('/counters',(req,res)=>{
+  for (const [key, value] of Object.entries(req.body)) {
+    counters[key] = value;
+  }
   res.send(counters);
 });
 


### PR DESCRIPTION
All counters are maintained in memory.
              
GET /counters/  List of counters in a map/dictionary format ({ “abc”: 5, “xyz”: 3 })
POST /counters  Creates a new counter with an initial value { “counter”: initialValue }
PUT /counters/:counter  Increases a counter value by one (no body required). Fails if counter does not exist (404 Not found)
DEL /counters/:counter  Decreases a counter value by one, if value <= 0 the counter disappears. Does fail if the counter does not exist.
GET /counters/:counter  Returns value of counter {“counter1”: 5}. Fails if the counter does not exist (404 Not found)
